### PR TITLE
Fix/get it running

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ You must add the following config variables to get the app up and running:
 SECRET_KEY
 ```
 
+#### django-compressor notes
+Heroku may not run compressor. In this case we'll need to add a `bin/post-compile` sh file for Heroku to run after building the slug.
+
+To check that `django-compressor` is running locally, run:  
+`python portland_python/manage.py compress`
+
 #### Deploying Branches
 Local branches can be deployed to heroku too!
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SECRET_KEY
 ```
 
 #### django-compressor notes
-Heroku may not run compressor. In this case we'll need to add a `bin/post-compile` sh file for Heroku to run after building the slug.
+Heroku may not run compressor. In this case we'll need to add a `bin/post_compile` sh file for Heroku to run after building the slug.
 
 To check that `django-compressor` is running locally, run:  
 `python portland_python/manage.py compress`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 New Portland Python Website
 
 ### Delpoy notes
+A couple notes to get up and running on a new heroku app.
+
+#### Setting the heroku buildpack
 Since a `package.json` and a `requirements.txt` exist in the repo, Heroku gets a little
 confused and thinks the repo is both a Node.js and Python app. Heroku will default to Node.js in this
 case and we must either tell Heroku that this is a python app.  
@@ -19,7 +22,27 @@ remote:
 remote: -----> Creating runtime environment
 ```
 
+And in the server log we can see that gunicorn isn't installed:
+
+```
+2016-01-29T18:09:07.351681+00:00 app[web.1]: bash: gunicorn: command not found
+```
+
 The buildpack can be set by the command: `heroku buildpacks:set heroku/python` or in a multi-buildpack scenario
 we can add additional buildpacks with the comand: `heroku buildpacks:add --index 1 heroku/nodejs`
 
 See: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app
+
+
+#### Requires config
+You must add the following config variables to get the app up and running:
+
+```
+SECRET_KEY
+```
+
+#### Deploying Branches
+Local branches can be deployed to heroku too!
+
+`git push heroku fix/16-config-for-heroku:master`
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,23 @@
 ![Travis CI Build Status](https://travis-ci.org/portlandpython/portlandpython.org.svg?branch=master)
 
 New Portland Python Website
+
+### Delpoy notes
+Since a `package.json` and a `requirements.txt` exist in the repo, Heroku gets a little
+confused and thinks the repo is both a Node.js and Python app. Heroku will default to Node.js in this
+case and we must either tell Heroku that this is a python app.  
+If we want to install JS dependencies from the `pagackage.json`, then we'll need to set up a multi-buildpack.
+
+```console
+remote: -----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
+remote:        Detected buildpacks: Node.js, Python
+remote:        See https://devcenter.heroku.com/articles/buildpacks#buildpack-detect-order
+remote: -----> Node.js app detected
+remote:
+remote: -----> Creating runtime environment
+```
+
+The buildpack can be set by the command: `heroku buildpacks:set heroku/python` or in a multi-buildpack scenario
+we can add additional buildpacks with the comand: `heroku buildpacks:add --index 1 heroku/nodejs`
+
+See: https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# The post_compile hook is run by heroku-buildpack-python
+
+echo "-----> I'm post-compile hook"
+
+# Work around Heroku bug whereby pylibmc isn't available during
+# compile phase. See: https://github.com/heroku/heroku-buildpack-python/issues/57
+export MEMCACHE_SERVERS='' MEMCACHIER_SERVERS=''
+
+if [ -f bin/run_collectstatic ]; then
+    echo "-----> Running run_collectstatic"
+    chmod +x bin/run_collectstatic
+    bin/run_collectstatic
+fi
+
+if [ -f bin/run_compress ]; then
+    echo "-----> Running run_compress"
+    chmod +x bin/run_compress
+    bin/run_compress
+fi
+
+# TODO in the future when a DB is needed: mirate currently fails with error:
+# ImportError: No module named portland_python.config.urls
+# if [ -f bin/run_migrate ]; then
+#     echo "-----> Running run_migrate"
+#     chmod +x bin/run_migrate
+#     bin/run_migrate
+# fi
+
+
+
+echo "-----> Post-compile done"
+

--- a/bin/run_collectstatic
+++ b/bin/run_collectstatic
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+indent() {
+    RE="s/^/       /"
+    [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
+}
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=${MANAGE_FILE:2}
+
+echo "-----> Collecting static files"
+python $MANAGE_FILE collectstatic --noinput  2>&1 | sed '/^Copying/d;/^$/d;/^ /d' | indent
+
+echo

--- a/bin/run_compress
+++ b/bin/run_compress
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+indent() {
+    RE="s/^/       /"
+    [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
+}
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=${MANAGE_FILE:2}
+
+echo "-----> Compressing static files"
+python $MANAGE_FILE compress 2>&1 | indent
+
+echo

--- a/bin/run_migrate
+++ b/bin/run_migrate
@@ -9,7 +9,7 @@ indent() {
 MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
 MANAGE_FILE=${MANAGE_FILE:2}
 
-echo "-----> Collecting static files"
+echo "-----> Running migrate"
 python $MANAGE_FILE migrate --noinput  2>&1 | sed '/^Copying/d;/^$/d;/^ /d' | indent
 
 echo

--- a/bin/run_migrate
+++ b/bin/run_migrate
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+indent() {
+    RE="s/^/       /"
+    [ $(uname) == "Darwin" ] && sed -l "$RE" || sed -u "$RE"
+}
+
+MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
+MANAGE_FILE=${MANAGE_FILE:2}
+
+echo "-----> Collecting static files"
+python $MANAGE_FILE migrate --noinput  2>&1 | sed '/^Copying/d;/^$/d;/^ /d' | indent
+
+echo

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,3 +1,4 @@
 Patrick Beeson @patrickbeeson
 Hannes Hapke @hanneshapke
 Chris Freeman @chrisfreemanpdx
+Aleck Landgraf @aleck_landgraf

--- a/portland_python/config/settings/base.py
+++ b/portland_python/config/settings/base.py
@@ -63,7 +63,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
 )
 
-ROOT_URLCONF = 'config.urls'
+ROOT_URLCONF = 'portland_python.config.urls'
 
 TEMPLATES = [
     {
@@ -85,7 +85,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'config.wsgi.application'
+# WSGI_APPLICATION = 'portland_python.config.wsgi.application'
 
 SITE_ID = 1
 

--- a/portland_python/config/settings/production.py
+++ b/portland_python/config/settings/production.py
@@ -1,9 +1,6 @@
 from os import environ
-import json
 from unipath import Path
 import dj_database_url
-
-from django.core.exceptions import ImproperlyConfigured
 
 from .base import *
 
@@ -11,13 +8,15 @@ BASE_DIR = Path(__file__).ancestor(3)
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
 TIME_ZONE = 'America/Los_Angeles'
 
-DATABASES['default'] =  dj_database_url.config()
+DATABASES['default'] = dj_database_url.config()
 
 SECRET_KEY = environ.get('SECRET_KEY')
 

--- a/portland_python/config/settings/production.py
+++ b/portland_python/config/settings/production.py
@@ -21,3 +21,6 @@ DATABASES['default'] = dj_database_url.config()
 SECRET_KEY = environ.get('SECRET_KEY')
 
 COMPRESS_OFFLINE = True
+
+# create .css and .css.gz, whitenoise will serve if browser supported
+COMPRESS_STORAGE = 'compressor.storage.GzipCompressorFileStorage'

--- a/portland_python/config/wsgi.py
+++ b/portland_python/config/wsgi.py
@@ -8,12 +8,16 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
 import os
+import sys
 
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
+root_path = os.path.abspath(os.path.split(__file__)[0])
+sys.path.insert(0, root_path)
+
 os.environ.setdefault(
-    "DJANGO_SETTINGS_MODULE", "config.settings.production")
+    "DJANGO_SETTINGS_MODULE", "portland_python.config.settings.production")
 
 application = get_wsgi_application()
 application = DjangoWhiteNoise(application)

--- a/portland_python/manage.py
+++ b/portland_python/manage.py
@@ -2,6 +2,9 @@
 import os
 import sys
 
+root_path = os.path.abspath(os.path.split(__file__)[0])
+sys.path.insert(0, root_path)
+
 if __name__ == "__main__":
     os.environ.setdefault(
         "DJANGO_SETTINGS_MODULE", "config.settings.production")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dj-database-url==0.3.0
 dj-static==0.0.6
 Django==1.9
 django-appconf==1.0.1
-django-compressor==1.6
+django-compressor==2.0
 django-debug-toolbar==1.4
 django-extensions==1.6.1
 django-libsass==0.6


### PR DESCRIPTION
It's running here: https://pdxpython.herokuapp.com/

This is branched off of @hanneshapke #17 

I added deploy notes to the README to get it running on heroku, which boils down to:
1. Heroku thinks the repo is a Node.js  app because of the `package.json` file and an Python app and defaults to Node.js. This can be solved by removing the `package.json` file **or** setting the app type via the command `heroku buildpacks:set heroku/python` **or** if we need Heorku to install the JS dependencies from `package.json` we'll need to set a multi-buildpack, e.g. Node.js and Python, install both dependencies and then run as a Python app, e.g. `heroku buildpacks:add --index 1 heroku/nodejs`
2. `django-compressor` was at a version that either didn't work with the python version or didn't work with the Django version. I upped it to the latest, `2.0`, and it runs locally and on Heroku.
3. `django-compressor` wasn't being run. I added a `bin/post_compile` dir and file which Heroku will execute after installing dependencies. `post_compile` runs the `collectstatic` and `compress` management commands. 

So it's running, but there are some bugs:

I don't think 404s or 500s are handled at this point:

```
2016-01-29T19:27:47.301095+00:00 app[web.1]: ImproperlyConfigured at /favicon.ico
2016-01-29T19:27:47.301096+00:00 app[web.1]: settings.DATABASES is improperly configured. Please supply the ENGINE value. Check settings documentation for more details.
```

I have a number of other recommendations, but it's working so I stopped here.
- move `manage.py` to the root of the app would help out
- one settings file, for tests you can have the test runner be something like `SECRET_KEY=abc cd portland_python;python manage.py test` if Travis cannot set a `SECRET_KEY` config var
- better error logging and reporting, maybe sentry or something free
- ~~deploy to heroku button for new folks to get spun up~~ **DONE!** check this out: 
  - https://github.com/alecklandgraf/portlandpython.org/pull/1
  - https://github.com/alecklandgraf/portlandpython.org

P.s.  `manage.py migrate` also fails in a weird way, considering no database is defined in settings, I thought that'd be the error, but it has something to do with loading urls.

P.p.s. I also configured `django-compressor` to create gzip versions of the css and js files. `whitenoise` will serve the gzipped version if the browser support or will fall back to the raw css.

![image](https://cloud.githubusercontent.com/assets/2336595/12689149/c99babde-c68f-11e5-8131-6c41ce367b43.png)

```
┌alandgraf@myhost ~
└> curl -I -H "Accept-Encoding: gzip" https://pdxpython.herokuapp.com/static/CACHE/css/c86cdf47592f.css
HTTP/1.1 200 OK
Connection: keep-alive
Server: gunicorn/19.3.0
Date: Fri, 29 Jan 2016 21:49:55 GMT
Last-Modified: Fri, 29 Jan 2016 21:48:26 GMT
Content-Type: text/css; charset="utf-8"
Cache-Control: public, max-age=60
Access-Control-Allow-Origin: *
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 18812
Via: 1.1 vegur
```

Cheers,
Aleck
